### PR TITLE
use the debian node container instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:current-alpine
+FROM node:current
 
 ARG DISCORD_SECRET
 ARG IMAGE
 ARG TAG
 ARG BUILD
 
+# TODO: this needs to be reworked so that state can be externalized with mounts, without replacing the contents of the installation itself!
 WORKDIR /usr/src/"${IMAGE}"
 COPY . /usr/src/"${IMAGE}"
 


### PR DESCRIPTION
Various node packages fail to run using node:current-alpine due to MUSL vs GLIBC issues. Sadface.

Also add a note about needing to revisit the workdir.